### PR TITLE
PR for health check and condition in docker-compose.yaml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
         dockerfile: Dockerfile
       ports:
         - "8080:8080"
-     depends_on:
+      depends_on:
       mysql:
         condition: service_healthy
       environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,11 @@ services:
       MYSQL_USER: product_user
       MYSQL_PASSWORD: product_user_password
       MYSQL_DATABASE: product
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 10s
+      retries: 5
+      start_period: 10s 
 
   spring-boot-app:
       build:
@@ -16,8 +21,9 @@ services:
         dockerfile: Dockerfile
       ports:
         - "8080:8080"
-      depends_on:
-        - mysql
+     depends_on:
+      mysql:
+        condition: service_healthy
       environment:
         SPRING_DATASOURCE_URL: jdbc:mysql://mysql:3306/product
         SPRING_DATASOURCE_USERNAME: product_user


### PR DESCRIPTION
Adding changes to docker-compose.yaml to run the backend container efficiently because whenever we run docker compose on our local through docker desktop the spring boot container looks for mysql database and exits so added a wait time and depends on block. 